### PR TITLE
Parser error for month field without braces in BibTeX.

### DIFF
--- a/_scripts/bib2md.py
+++ b/_scripts/bib2md.py
@@ -243,7 +243,7 @@ def cleanup(e):
     e['added'] = date.today()
 
 def main():
-    parser = BibTexParser()
+    parser = BibTexParser(common_strings=True)
     parser.customization = homogenize_latex_encoding
     x = sys.stdin.read()
     x = x.replace('$\{$', '{')


### PR DESCRIPTION
Known issue, https://github.com/sciunto-org/python-bibtexparser/issues/201.